### PR TITLE
Categorize doccommentdata's child nodes as system

### DIFF
--- a/repository/src/main/resources/hcm-config/doccommentdata.yaml
+++ b/repository/src/main/resources/hcm-config/doccommentdata.yaml
@@ -2,3 +2,4 @@ definitions:
   config:
     /doccommentdata:
       jcr:primaryType: doccommenting:commentdatacontainer
+      .meta:residual-child-node-category: system


### PR DESCRIPTION
This will prevent doccommentdata's existing child nodes to be deleted when migrating from Hippo 11 to Hippo 12.