### PR TITLE
FORGE-593 Upgrade Document Commenting to BrXM v17 / Java 21

### DIFF
--- a/cms/pom.xml
+++ b/cms/pom.xml
@@ -16,7 +16,7 @@
   <parent>
     <groupId>org.bloomreach.forge.doc-commenting</groupId>
     <artifactId>doc-commenting</artifactId>
-    <version>7.0.2-SNAPSHOT</version>
+    <version>8.0.0-SNAPSHOT</version>
   </parent>
 
   <name>Bloomreach XM Document Commenting Plugin - CMS</name>
@@ -88,7 +88,7 @@
     </dependency>
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
-      <artifactId>log4j-slf4j-impl</artifactId>
+      <artifactId>log4j-slf4j2-impl</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/demo/cms-dependencies/pom.xml
+++ b/demo/cms-dependencies/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.bloomreach.forge.doc-commenting</groupId>
     <artifactId>doccommentingdemo</artifactId>
-    <version>7.0.2-SNAPSHOT</version>
+    <version>8.0.0-SNAPSHOT</version>
   </parent>
   <artifactId>doccommentingdemo-cms-dependencies</artifactId>
   <packaging>pom</packaging>

--- a/demo/cms/pom.xml
+++ b/demo/cms/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.bloomreach.forge.doc-commenting</groupId>
     <artifactId>doccommentingdemo</artifactId>
-    <version>7.0.2-SNAPSHOT</version>
+    <version>8.0.0-SNAPSHOT</version>
   </parent>
   <artifactId>doccommentingdemo-cms</artifactId>
   <packaging>war</packaging>

--- a/demo/essentials/pom.xml
+++ b/demo/essentials/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.bloomreach.forge.doc-commenting</groupId>
     <artifactId>doccommentingdemo</artifactId>
-    <version>7.0.2-SNAPSHOT</version>
+    <version>8.0.0-SNAPSHOT</version>
   </parent>
   <artifactId>doccommentingdemo-essentials</artifactId>
   <packaging>war</packaging>

--- a/demo/pom.xml
+++ b/demo/pom.xml
@@ -2,25 +2,35 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
-  <parent>
+  <!-- Switch parent to run demo as community project (remove the 'enterprise' profile from ~/.m2/settings.xml) -->
+  <!--parent>
     <groupId>org.onehippo.cms7</groupId>
     <artifactId>hippo-cms7-release</artifactId>
-    <version>16.2.0</version>
-  </parent>
+    <version>17.0.0</version>
+  </parent-->
 
   <!-- Switch parent to run demo as enterprise project (make sure to build with additional profile 'enterprise') -->
-  <!--parent>
+  <parent>
     <groupId>com.onehippo.cms7</groupId>
     <artifactId>hippo-cms7-enterprise-release</artifactId>
-    <version>16.2.0</version>
-  </parent-->
+    <version>17.0.0</version>
+    <relativePath/>
+  </parent>
 
   <name>Bloomreach Document Commenting Plugin Demo</name>
   <description>Bloomreach Document Commenting Plugin Demo</description>
   <groupId>org.bloomreach.forge.doc-commenting</groupId>
   <artifactId>doccommentingdemo</artifactId>
-  <version>7.0.2-SNAPSHOT</version>
+  <version>8.0.0-SNAPSHOT</version>
   <packaging>pom</packaging>
+
+  <modules>
+    <module>cms-dependencies</module>
+    <module>repository-data</module>
+    <module>cms</module>
+    <module>site</module>
+    <module>essentials</module>
+  </modules>
 
   <!--
     The below project elements are emptied/overridden as otherwise their metadata would be
@@ -70,7 +80,7 @@
     <!--***START temporary override of versions*** -->
     <!-- ***END temporary override of versions*** -->
 
-    <essentials.version>16.0.0</essentials.version>
+    <essentials.version>17.0.0</essentials.version>
 
     <development-module-deploy-dir>shared/lib</development-module-deploy-dir>
 
@@ -196,23 +206,6 @@
           </releases>
         </repository>
       </repositories>
-    </profile>
-
-    <profile>
-      <id>default</id>
-      <activation>
-        <activeByDefault>true</activeByDefault>
-        <property>
-          <name>jrebel</name>
-        </property>
-      </activation>
-      <modules>
-        <module>cms-dependencies</module>
-        <module>repository-data</module>
-        <module>cms</module>
-        <module>site</module>
-        <module>essentials</module>
-      </modules>
     </profile>
 
     <profile>

--- a/demo/repository-data/application/pom.xml
+++ b/demo/repository-data/application/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.bloomreach.forge.doc-commenting</groupId>
     <artifactId>doccommentingdemo-repository-data</artifactId>
-    <version>7.0.2-SNAPSHOT</version>
+    <version>8.0.0-SNAPSHOT</version>
   </parent>
 
   <name>Bloomreach Document Commenting Plugin Demo Repository Data For Application</name>

--- a/demo/repository-data/development/pom.xml
+++ b/demo/repository-data/development/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.bloomreach.forge.doc-commenting</groupId>
     <artifactId>doccommentingdemo-repository-data</artifactId>
-    <version>7.0.2-SNAPSHOT</version>
+    <version>8.0.0-SNAPSHOT</version>
   </parent>
 
   <name>Bloomreach Document Commenting Plugin Demo Repository Data For Development</name>

--- a/demo/repository-data/pom.xml
+++ b/demo/repository-data/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.bloomreach.forge.doc-commenting</groupId>
     <artifactId>doccommentingdemo</artifactId>
-    <version>7.0.2-SNAPSHOT</version>
+    <version>8.0.0-SNAPSHOT</version>
   </parent>
 
   <name>Bloomreach Document Commenting Plugin Demo Repository Data</name>

--- a/demo/repository-data/site-development/pom.xml
+++ b/demo/repository-data/site-development/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.bloomreach.forge.doc-commenting</groupId>
     <artifactId>doccommentingdemo-repository-data</artifactId>
-    <version>7.0.2-SNAPSHOT</version>
+    <version>8.0.0-SNAPSHOT</version>
   </parent>
 
   <name>Bloomreach Document Commenting Plugin Demo Repository Data For Site Development</name>

--- a/demo/repository-data/site/pom.xml
+++ b/demo/repository-data/site/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.bloomreach.forge.doc-commenting</groupId>
     <artifactId>doccommentingdemo-repository-data</artifactId>
-    <version>7.0.2-SNAPSHOT</version>
+    <version>8.0.0-SNAPSHOT</version>
   </parent>
 
   <name>Bloomreach Document Commenting Plugin Demo Repository Data For Site</name>

--- a/demo/repository-data/webfiles/pom.xml
+++ b/demo/repository-data/webfiles/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.bloomreach.forge.doc-commenting</groupId>
     <artifactId>doccommentingdemo-repository-data</artifactId>
-    <version>7.0.2-SNAPSHOT</version>
+    <version>8.0.0-SNAPSHOT</version>
   </parent>
 
   <name>Bloomreach Document Commenting Plugin Demo Repository Data Web Files</name>

--- a/demo/site/components/pom.xml
+++ b/demo/site/components/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.bloomreach.forge.doc-commenting</groupId>
     <artifactId>doccommentingdemo-site</artifactId>
-    <version>7.0.2-SNAPSHOT</version>
+    <version>8.0.0-SNAPSHOT</version>
   </parent>
   <artifactId>doccommentingdemo-components</artifactId>
   <packaging>jar</packaging>

--- a/demo/site/pom.xml
+++ b/demo/site/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.bloomreach.forge.doc-commenting</groupId>
     <artifactId>doccommentingdemo</artifactId>
-    <version>7.0.2-SNAPSHOT</version>
+    <version>8.0.0-SNAPSHOT</version>
   </parent>
   <artifactId>doccommentingdemo-site</artifactId>
   <packaging>pom</packaging>

--- a/demo/site/webapp/pom.xml
+++ b/demo/site/webapp/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.bloomreach.forge.doc-commenting</groupId>
     <artifactId>doccommentingdemo-site</artifactId>
-    <version>7.0.2-SNAPSHOT</version>
+    <version>8.0.0-SNAPSHOT</version>
   </parent>
   <artifactId>doccommentingdemo-webapp</artifactId>
   <packaging>war</packaging>

--- a/pom.xml
+++ b/pom.xml
@@ -16,14 +16,14 @@
   <parent>
     <groupId>org.onehippo.cms7</groupId>
     <artifactId>hippo-cms7-project</artifactId>
-    <version>16.2.0</version>
+    <version>17.0.0</version>
   </parent>
 
   <name>Bloomreach XM Document Commenting Plugin</name>
   <description>Bloomreach XM Document Commenting Plugin</description>
   <groupId>org.bloomreach.forge.doc-commenting</groupId>
   <artifactId>doc-commenting</artifactId>
-  <version>7.0.2-SNAPSHOT</version>
+  <version>8.0.0-SNAPSHOT</version>
   <packaging>pom</packaging>
   <url>https://bloomreach-forge.github.io/document-commenting</url>
 
@@ -71,7 +71,7 @@
 
   <issueManagement>
     <system>Jira</system>
-    <url>https://issues.onehippo.com/browse/HIPFORGE</url>
+    <url>https://bloomreach.atlassian.net/browse/FORGE</url>
   </issueManagement>
 
 
@@ -137,7 +137,7 @@
       <dependency>
         <groupId>org.slf4j</groupId>
         <artifactId>slf4j-api</artifactId>
-        <version>${slf4j.version}</version>
+        <version>${slf4j2.version}</version>
         <scope>provided</scope>
       </dependency>
 
@@ -160,12 +160,12 @@
       <dependency>
         <groupId>org.slf4j</groupId>
         <artifactId>jcl-over-slf4j</artifactId>
-        <version>${slf4j.version}</version>
+        <version>${slf4j2.version}</version>
         <scope>test</scope>
       </dependency>
       <dependency>
         <groupId>org.apache.logging.log4j</groupId>
-        <artifactId>log4j-slf4j-impl</artifactId>
+        <artifactId>log4j-slf4j2-impl</artifactId>
         <version>${log4j2.version}</version>
         <scope>test</scope>
       </dependency>
@@ -192,7 +192,7 @@
       <dependency>
         <groupId>junit</groupId>
         <artifactId>junit</artifactId>
-        <version>${junit.version}</version>
+        <version>${junit4.version}</version>
         <scope>test</scope>
       </dependency>
 

--- a/repository/pom.xml
+++ b/repository/pom.xml
@@ -16,7 +16,7 @@
   <parent>
     <groupId>org.bloomreach.forge.doc-commenting</groupId>
     <artifactId>doc-commenting</artifactId>
-    <version>7.0.2-SNAPSHOT</version>
+    <version>8.0.0-SNAPSHOT</version>
   </parent>
 
   <name>Bloomreach XM Document Commenting Plugin - Repository</name>
@@ -64,7 +64,7 @@
     </dependency>
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
-      <artifactId>log4j-slf4j-impl</artifactId>
+      <artifactId>log4j-slf4j2-impl</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
## Summary
- Bump `hippo-cms7-project` / `hippo-cms7-enterprise-release` parent from `16.2.0` → `17.0.0`
- Advance plugin version to `8.0.0-SNAPSHOT`
- Fix v17 BOM breaking changes: `${slf4j.version}` → `${slf4j2.version}`, `log4j-slf4j-impl` → `log4j-slf4j2-impl`, `${junit.version}` → `${junit4.version}`
- Move demo modules from `activeByDefault` profile to root pom (fixes build when `enterprise` profile is globally active in `~/.m2/settings.xml`)
- Switch demo parent to `hippo-cms7-enterprise-release:17.0.0`
- Create `support/7.x` maintenance branch to preserve v16 line
- Fix `issueManagement` URL: `issues.onehippo.com` → `bloomreach.atlassian.net`

## Test plan
- [ ] `mvn clean install` passes on plugin root (Java 21)
- [ ] `cd demo && mvn clean verify -T4C -DskipTests` builds all submodules
- [ ] `mvn -Pcargo.run` starts CMS at `http://localhost:8080/cms`
- [ ] Document Commenting field renders in document editor
- [ ] Add / edit / delete a comment on a document

Closes FORGE-593

🤖 Generated with [Claude Code](https://claude.com/claude-code)